### PR TITLE
WIP: Client schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.2",
     "coveralls": "~2.11.3",
+    "ht-tv4": "^0.1.0",
     "istanbul": "~0.4.0",
     "mocha": "~2.4.5",
     "nyc": "^5.6.0"

--- a/src/service.js
+++ b/src/service.js
@@ -131,6 +131,28 @@ let Service = function Service(Transports, config) {
         utils.getLastResult.call(this, data, callback, true);
     });
 
+    this.on("$htGetSchema", s.String(), (methodName, callback) => {
+        let method = this._methods[methodName];
+        if(!method) {
+            return callback({
+                error:  "unknown-method",
+                method: methodName
+            });
+        }
+        let schema = method.schema;
+        if(!schema) {
+            return callback();
+        }
+        // We allow non ht-schema validation schemas
+        // too, so make sure it has a document fn
+        if(typeof schema.document !== 'function') {
+            return callback({
+                error: "incompatible-schema"
+            });
+        }
+        return callback(null, schema.document());
+    });
+
     Transports.forEach((transport) => {
         this.addTransport(transport);
     });

--- a/test/client.js
+++ b/test/client.js
@@ -926,7 +926,53 @@ describe("Client", function() {
 
     });
 
-    describe("schemas", function() {
+    describe("Request Schemas", function() {
+
+        describe("addRequestSchema", function() {
+
+            it("should add a schema", function() {
+
+                let client = new Client();
+
+                client.addRequestSchema("hello", "world", s.String());
+
+                assert.equal(typeof client.requestSchemas.hello.world.validate, 'function');
+
+            });
+
+            it("should add multiple schemas", function() {
+
+                let client = new Client();
+
+                client.addRequestSchema("helloworld", "str", s.String());
+                client.addRequestSchema("helloworld", "num", s.Number());
+                client.addRequestSchema("blah", "foo", s.Date());
+
+                assert.equal(typeof client.requestSchemas.helloworld.str.validate, 'function');
+                assert.equal(typeof client.requestSchemas.helloworld.num.validate, 'function');
+                assert.equal(typeof client.requestSchemas.blah.foo.validate, 'function');
+
+            });
+
+            it("should throw if schema doesn't have validate fn", function() {
+
+                let client = new Client();
+
+                let schema = {};
+
+                let _method = "blah";
+
+                assert.throws(function() {
+                    client.addRequestSchema("foo", _method, schema);
+                }, new RegExp(`Schema for ${_method} does not have a validate function.`));
+
+            });
+
+        });
+
+    });
+
+    describe("Response Schemas", function() {
 
         it("should be able to add schemas", function() {
 
@@ -1080,7 +1126,7 @@ describe("Client", function() {
                 s1: httv4
             }, function(err) {
                 assert.ifError(err);
-                assert.notEqual(client.requestSchemas.s1.method1, undefined);
+                assert.equal(typeof client.requestSchemas.s1.method1.validate, 'function');
                 client.requestSchemas.s1.method1.validate({
                     input: "blah"
                 }, function(err, response) {

--- a/test/service.js
+++ b/test/service.js
@@ -722,6 +722,86 @@ describe("Service", function() {
 
   });
 
+  describe("$htGetSchema", function() {
+
+    it("should return unknown-method if called with unknown method", function(done) {
+
+      let service = new Service();
+      let _method = "hello-world";
+
+      service.call("$htGetSchema", _method, function(err) {
+        assert.equal(err.error, "unknown-method");
+        assert.equal(err.method, _method);
+        done();
+      });
+
+    });
+
+    it("should return nothing if method has no schema", function(done) {
+
+      let service = new Service();
+      let _method = "hello-world";
+
+      service.on(_method, function(data, callback) { 
+        return callback(null, data);
+      });
+
+      service.call("$htGetSchema", _method, function(err, response) {
+        assert.ifError(err);
+        assert.strictEqual(response, undefined);
+        done();
+      });
+
+    });
+
+    it("should return incompatible-schema if called with a schema with no document fn", function(done) {
+
+      let service = new Service();
+      let _method = "hello-world";
+
+      let schema = {
+        validate: function(data, callback) {
+          return callback(null, data);
+        }
+      }
+
+      service.on(_method, schema, function(data, callback) {
+        return callback(null, data);
+      });
+
+      service.call("$htGetSchema", _method, function(err) {
+        assert.equal(err.error, "incompatible-schema");
+        done();
+      });
+
+    });
+
+    it("should return schema if called with known method", function(done) {
+
+      let service = new Service();
+      let _method = "hello-world";
+
+      let schema = s.Object({
+        string: s.String(),
+        number: s.Number(),
+        array:  s.Array([ s.String(), s.Number() ]),
+        opt:    s.String({ opt: true })
+      });
+
+      service.on(_method, schema, function(data, callback) {
+        return callback(null, data);
+      });
+
+      service.call("$htGetSchema", _method, function(err, _schema) {
+        assert.ifError(err);
+        assert.deepEqual(_schema, schema.document());
+        done();
+      });
+
+    });
+
+  });
+
 });
 
 function mockTransport(fns) {

--- a/test/service.js
+++ b/test/service.js
@@ -802,6 +802,73 @@ describe("Service", function() {
 
   });
 
+  describe("$htGetAllSchemas", function() {
+
+    it("should return schemas for all methods on service", function(done) {
+
+      function noop() {};
+
+      let service = new Service();
+
+      let schema1 = s.Object({
+        s1: s.String()
+      });
+
+      let schema2 = s.Object({
+        s2: s.Object({ opt: true }, {
+          key: s.Object({
+            value: s.Boolean({ default: true, opt: true })
+          })
+        })
+      });
+
+      service.on("method1", schema1, noop);
+      service.on("method2", schema2, noop);
+
+      service.call("$htGetAllSchemas", null, function(err, schemas) {
+        assert.ifError(err);
+
+        assert.deepEqual(schemas, {
+          method1: schema1.document(),
+          method2: schema2.document()
+        });
+
+        done();
+      });
+
+    });
+
+    it("should skip schema if it has incompatible schema type", function(done) {
+
+      function noop() {};
+
+      let service = new Service();
+
+      let schema1 = {
+        validate: function(data, callback) {
+          return callback(null, data);
+        }
+      }
+
+      let schema2 = s.String({ opt: true });
+
+      service.on("method1", schema1, noop);
+      service.on("method2", schema2, noop);
+
+      service.call("$htGetAllSchemas", null, function(err, schemas) {
+        assert.ifError(err);
+
+        assert.deepEqual(schemas, {
+          method2: schema2.document()
+        });
+
+        done();
+      });
+
+    });
+
+  });
+
 });
 
 function mockTransport(fns) {


### PR DESCRIPTION
This PR will (eventually) allow clients to pull, and cache remote method schemas, so data can be locally validated before being sent to the server.
